### PR TITLE
Implement sales funnel with new Venda entity

### DIFF
--- a/back/src/main/java/com/securitygateway/crm/controller/VendaController.java
+++ b/back/src/main/java/com/securitygateway/crm/controller/VendaController.java
@@ -1,0 +1,55 @@
+package com.securitygateway.crm.controller;
+
+import com.securitygateway.crm.model.Venda;
+import com.securitygateway.crm.repository.VendaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/vendas")
+@RequiredArgsConstructor
+public class VendaController {
+
+    private final VendaRepository vendaRepository;
+
+    @GetMapping
+    public List<Venda> all() {
+        return vendaRepository.findAll(Sort.by(Sort.Direction.ASC, "id"));
+    }
+
+    @PostMapping
+    public ResponseEntity<Venda> create(@RequestBody Venda venda) {
+        return new ResponseEntity<>(vendaRepository.save(venda), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Venda> get(@PathVariable Long id) {
+        return vendaRepository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Venda> update(@PathVariable Long id, @RequestBody Venda updated) {
+        return vendaRepository.findById(id)
+                .map(existing -> {
+                    updated.setId(existing.getId());
+                    return ResponseEntity.ok(vendaRepository.save(updated));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (!vendaRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        vendaRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/back/src/main/java/com/securitygateway/crm/model/Venda.java
+++ b/back/src/main/java/com/securitygateway/crm/model/Venda.java
@@ -8,7 +8,7 @@ import java.math.BigDecimal;
 
 @Data
 @Entity
-public class Sale {
+public class Venda {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/back/src/main/java/com/securitygateway/crm/repository/SaleRepository.java
+++ b/back/src/main/java/com/securitygateway/crm/repository/SaleRepository.java
@@ -1,7 +1,0 @@
-package com.securitygateway.crm.repository;
-
-import com.securitygateway.crm.model.Sale;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface SaleRepository extends JpaRepository<Sale, Long> {
-}

--- a/back/src/main/java/com/securitygateway/crm/repository/VendaRepository.java
+++ b/back/src/main/java/com/securitygateway/crm/repository/VendaRepository.java
@@ -1,0 +1,7 @@
+package com.securitygateway.crm.repository;
+
+import com.securitygateway.crm.model.Venda;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VendaRepository extends JpaRepository<Venda, Long> {
+}

--- a/front/src/app/dashboard/sales/funnel.component.ts
+++ b/front/src/app/dashboard/sales/funnel.component.ts
@@ -1,10 +1,86 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { DragDropModule, CdkDragDrop, transferArrayItem, moveItemInArray } from '@angular/cdk/drag-drop';
+import { FormsModule } from '@angular/forms';
+import { VendaService } from '../../services/venda.service';
+import { Venda } from '../../models/venda.model';
 
 @Component({
   selector: 'app-funnel',
   standalone: true,
-  imports: [CommonModule],
-  template: '<p>Funil de Vendas</p>'
+  imports: [CommonModule, DragDropModule, FormsModule],
+  template: `
+    <div class="funnel">
+      <div
+        class="stage"
+        *ngFor="let stage of stages; let i = index"
+        cdkDropList
+        [cdkDropListData]="stage.vendas"
+        class="list"
+        (cdkDropListDropped)="dropSale($event, i)">
+        <header cdkDrag>{{ stage.name }} <button (click)="removeStage(i)">x</button></header>
+        <div class="card" *ngFor="let venda of stage.vendas" cdkDrag>{{ venda.modulo }} - {{ venda.valor | currency:'BRL' }}</div>
+      </div>
+      <div class="add-stage">
+        <input placeholder="Nova etapa" [(ngModel)]="newStage" />
+        <button (click)="addStage()">Adicionar</button>
+      </div>
+    </div>
+  `,
+  styles: [
+    `.funnel { display: flex; gap: 1rem; overflow-x: auto; }
+     .stage { background: #f7f7f7; padding: .5rem; width: 200px; border-radius: 4px; }
+     .list { min-height: 200px; }
+     header { font-weight: bold; margin-bottom: .5rem; cursor: move; display:flex; justify-content:space-between; }
+     .card { background: #fff; padding: .5rem; margin-bottom: .5rem; border: 1px solid #ddd; border-radius: 4px; cursor: move; }
+     .add-stage { display:flex; flex-direction:column; justify-content:flex-start; }
+    `]
 })
-export class FunnelComponent {}
+export class FunnelComponent {
+  stages: { name: string; vendas: Venda[] }[] = [
+    { name: 'Novas oportunidades', vendas: [] },
+    { name: 'Qualificação', vendas: [] },
+    { name: 'Apresentação do orçamento', vendas: [] },
+    { name: 'Negociação', vendas: [] },
+    { name: 'Fechamento', vendas: [] },
+  ];
+
+  newStage = '';
+
+  constructor(private vendaService: VendaService) {
+    this.vendaService.list().subscribe(vendas => {
+      vendas.forEach(v => {
+        const stage = this.stages.find(s => s.name === v.etapa);
+        if (stage) {
+          stage.vendas.push(v);
+        } else {
+          this.stages[0].vendas.push(v);
+        }
+      });
+    });
+  }
+
+  addStage() {
+    if (this.newStage.trim()) {
+      this.stages.push({ name: this.newStage.trim(), vendas: [] });
+      this.newStage = '';
+    }
+  }
+
+  removeStage(index: number) {
+    this.stages.splice(index, 1);
+  }
+
+  dropSale(event: CdkDragDrop<Venda[]>, stageIndex: number) {
+    if (event.previousContainer === event.container) {
+      moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
+    } else {
+      transferArrayItem(
+        event.previousContainer.data,
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex
+      );
+    }
+  }
+}

--- a/front/src/app/dashboard/sales/new-sale.component.ts
+++ b/front/src/app/dashboard/sales/new-sale.component.ts
@@ -1,10 +1,44 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { VendaService } from '../../services/venda.service';
+import { Venda } from '../../models/venda.model';
 
 @Component({
   selector: 'app-new-sale',
   standalone: true,
-  imports: [CommonModule],
-  template: '<p>Nova Venda</p>'
+  imports: [CommonModule, FormsModule],
+  template: `
+    <h2>Nova Venda</h2>
+    <form (ngSubmit)="create()">
+      <label>
+        Etapa:
+        <input name="etapa" [(ngModel)]="venda.etapa" required />
+      </label>
+      <label>
+        Módulo:
+        <input name="modulo" [(ngModel)]="venda.modulo" required />
+      </label>
+      <label>
+        Valor:
+        <input type="number" name="valor" [(ngModel)]="venda.valor" required />
+      </label>
+      <button type="submit">Salvar</button>
+    </form>
+  `
 })
-export class NewSaleComponent {}
+export class NewSaleComponent {
+  venda: Venda = {
+    cliente: null as any,
+    etapa: '',
+    modulo: '',
+    valor: 0,
+    vendedorResponsavel: null as any
+  };
+
+  constructor(private vendaService: VendaService) {}
+
+  create() {
+    this.vendaService.create(this.venda).subscribe();
+  }
+}

--- a/front/src/app/models/venda.model.ts
+++ b/front/src/app/models/venda.model.ts
@@ -1,0 +1,8 @@
+export interface Venda {
+  id?: number;
+  cliente: any;
+  etapa: string;
+  modulo: string;
+  valor: number;
+  vendedorResponsavel: any;
+}

--- a/front/src/app/services/venda.service.ts
+++ b/front/src/app/services/venda.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environmet/environment';
+import { Observable } from 'rxjs';
+import { Venda } from '../models/venda.model';
+
+@Injectable({ providedIn: 'root' })
+export class VendaService {
+  private apiUrl = `${environment.apiUrl}/vendas`;
+  constructor(private http: HttpClient) {}
+
+  list(): Observable<Venda[]> {
+    return this.http.get<Venda[]>(this.apiUrl);
+  }
+
+  create(venda: Venda): Observable<Venda> {
+    return this.http.post<Venda>(this.apiUrl, venda);
+  }
+
+  update(id: number, venda: Venda): Observable<Venda> {
+    return this.http.put<Venda>(`${this.apiUrl}/${id}`, venda);
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add Venda entity and controller in backend
- expose CRUD endpoints under `/api/v1/vendas`
- rename repository to `VendaRepository`
- implement minimal sales form to create a Venda
- implement Kanban style funnel with drag-and-drop and dynamic stages
- add frontend service and model for Venda

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858639077348329a897ef072ae52e89