### PR TITLE
Add user admin module with role management

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/controller/UserController.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/controller/UserController.java
@@ -1,0 +1,62 @@
+package com.securitygateway.loginboilerplate.controller;
+
+import com.securitygateway.loginboilerplate.model.Role;
+import com.securitygateway.loginboilerplate.model.User;
+import com.securitygateway.loginboilerplate.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserRepository userRepository;
+
+    @GetMapping
+    public List<User> list() {
+        return userRepository.findAll(Sort.by(Sort.Direction.ASC, "name.firstName"));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public ResponseEntity<User> update(@PathVariable Long id, @RequestBody User updated) {
+        return userRepository.findById(id)
+                .map(existing -> {
+                    updated.setId(existing.getId());
+                    if (updated.getPassword() == null) {
+                        updated.setPassword(existing.getPassword());
+                    }
+                    return ResponseEntity.ok(userRepository.save(updated));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}/role")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public ResponseEntity<User> updateRole(@PathVariable Long id, @RequestBody RoleChangeRequest request) {
+        return userRepository.findById(id)
+                .map(user -> {
+                    user.setRole(request.role());
+                    return ResponseEntity.ok(userRepository.save(user));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (!userRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        userRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    public record RoleChangeRequest(Role role) {}
+}

--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/Role.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/Role.java
@@ -2,5 +2,9 @@ package com.securitygateway.loginboilerplate.model;
 
 public enum Role {
     USER,
-    ADMIN
+    ADMIN,
+    DIRETOR_COMERCIAL,
+    GERENTE_VENDAS,
+    SDR,
+    VENDEDOR
 }

--- a/back/src/main/java/com/securitygateway/loginboilerplate/repository/UserRepository.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/repository/UserRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Integer>{
+public interface UserRepository extends JpaRepository<User, Long>{
     Optional<User> findByEmail(String email);
 }

--- a/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -19,6 +20,7 @@ import static org.springframework.security.web.util.matcher.AntPathRequestMatche
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfiguration {
     private final AuthenticationEntryPoint authenticationEntryPoint;

--- a/front/src/app/dashboard/users/manage-users.component.ts
+++ b/front/src/app/dashboard/users/manage-users.component.ts
@@ -1,10 +1,97 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { UserService } from '../../services/user.service';
+import { User, Role } from '../../models/user.model';
 
 @Component({
   selector: 'app-manage-users',
   standalone: true,
-  imports: [CommonModule],
-  template: '<p>Gerenciar Usuários</p>'
+  imports: [CommonModule, FormsModule],
+  template: `
+  <div *ngIf="!editing">
+    <table>
+      <thead>
+        <tr>
+          <th>Nome</th>
+          <th>Telefone</th>
+          <th>Email</th>
+          <th>Ações</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let u of users">
+          <td>{{ u.firstName }} {{ u.lastName }}</td>
+          <td>{{ u.phoneNumber }}</td>
+          <td>{{ u.email }}</td>
+          <td>
+            <button (click)="startEdit(u)">Editar</button>
+            <button (click)="remove(u.id)">Remover</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div *ngIf="editing">
+    <h3>Editar Usuário</h3>
+    <form (ngSubmit)="save()">
+      <label>
+        Nome:
+        <input name="firstName" [(ngModel)]="selected.firstName" />
+      </label>
+      <label>
+        Sobrenome:
+        <input name="lastName" [(ngModel)]="selected.lastName" />
+      </label>
+      <label>
+        Telefone:
+        <input name="phoneNumber" [(ngModel)]="selected.phoneNumber" />
+      </label>
+      <label>
+        Role:
+        <select name="role" [(ngModel)]="selected.role">
+          <option *ngFor="let r of roles" [value]="r">{{ r }}</option>
+        </select>
+      </label>
+      <button type="submit">Salvar</button>
+      <button type="button" (click)="cancel()">Cancelar</button>
+    </form>
+  </div>
+  `
 })
-export class ManageUsersComponent {}
+export class ManageUsersComponent implements OnInit {
+  users: User[] = [];
+  roles = Object.values(Role);
+  editing = false;
+  selected!: User;
+
+  constructor(private userService: UserService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load() {
+    this.userService.list().subscribe(u => this.users = u);
+  }
+
+  startEdit(user: User) {
+    this.selected = { ...user };
+    this.editing = true;
+  }
+
+  cancel() {
+    this.editing = false;
+  }
+
+  save() {
+    this.userService.update(this.selected.id, this.selected).subscribe(() => {
+      this.editing = false;
+      this.load();
+    });
+  }
+
+  remove(id: number) {
+    this.userService.delete(id).subscribe(() => this.load());
+  }
+}

--- a/front/src/app/models/user.model.ts
+++ b/front/src/app/models/user.model.ts
@@ -1,0 +1,18 @@
+export enum Role {
+  USER = 'USER',
+  ADMIN = 'ADMIN',
+  DIRETOR_COMERCIAL = 'DIRETOR_COMERCIAL',
+  GERENTE_VENDAS = 'GERENTE_VENDAS',
+  SDR = 'SDR',
+  VENDEDOR = 'VENDEDOR'
+}
+
+export interface User {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+  gender?: string;
+  role: Role;
+}

--- a/front/src/app/services/user.service.ts
+++ b/front/src/app/services/user.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environmet/environment';
+import { Observable } from 'rxjs';
+import { User, Role } from '../models/user.model';
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  private apiUrl = `${environment.apiUrl}/users`;
+
+  constructor(private http: HttpClient) {}
+
+  list(): Observable<User[]> {
+    return this.http.get<User[]>(this.apiUrl);
+  }
+
+  update(id: number, user: Partial<User>): Observable<User> {
+    return this.http.put<User>(`${this.apiUrl}/${id}`, user);
+  }
+
+  updateRole(id: number, role: Role): Observable<User> {
+    return this.http.put<User>(`${this.apiUrl}/${id}/role`, { role });
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+  }
+}


### PR DESCRIPTION
## Summary
- define additional user roles
- add user admin controller for CRUD and role updates
- enable method security
- adapt repository id type
- implement frontend admin page and service for managing users

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587522aee083298c76e63c15830ff0