### PR TITLE
Fix user management table, safe delete

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/configuration/ApplicationConfiguration.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/configuration/ApplicationConfiguration.java
@@ -24,7 +24,7 @@ public class ApplicationConfiguration {
 
     @Bean
     public UserDetailsService userDetailsService(){
-        return username -> userRepository.findByEmail(username)
+        return username -> userRepository.findByEmailAndDeletedFalse(username)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
     }
 

--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/User.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/User.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.Collection;
 import java.util.List;
@@ -57,7 +58,10 @@ public class User implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    private Boolean deleted = false;
+
     @Override
+    @JsonIgnore
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority(role.name()));
     }

--- a/back/src/main/java/com/securitygateway/loginboilerplate/repository/UserRepository.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/repository/UserRepository.java
@@ -4,7 +4,13 @@ import com.securitygateway.loginboilerplate.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.List;
+import org.springframework.data.domain.Sort;
 
 public interface UserRepository extends JpaRepository<User, Long>{
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmailAndDeletedFalse(String email);
+
+    List<User> findByDeletedFalse(Sort sort);
 }

--- a/back/src/main/java/com/securitygateway/loginboilerplate/service/implementation/AuthenticationServiceImplementation.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/service/implementation/AuthenticationServiceImplementation.java
@@ -131,7 +131,7 @@ public class AuthenticationServiceImplementation implements AuthenticationServic
         String emailEntered = registerVerifyRequest.getEmail().trim().toLowerCase();
         String otpEntered = registerVerifyRequest.getOtp().trim();
         try {
-            User user = userRepository.findByEmail(emailEntered).orElseThrow(
+            User user = userRepository.findByEmailAndDeletedFalse(emailEntered).orElseThrow(
                     ResourceNotFoundException::new
             );
             String cachedOtp = cacheManager.getCache("user").get(emailEntered, String.class);
@@ -161,7 +161,7 @@ public class AuthenticationServiceImplementation implements AuthenticationServic
         String email = loginRequest.getEmail().trim().toLowerCase();
         String password = loginRequest.getPassword();
         try {
-            User user = userRepository.findByEmail(email).orElseThrow(
+            User user = userRepository.findByEmailAndDeletedFalse(email).orElseThrow(
                         ResourceNotFoundException::new
                 );
             authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password));
@@ -199,7 +199,7 @@ public class AuthenticationServiceImplementation implements AuthenticationServic
     public ResponseEntity<?> resendOtp(ForgotPasswordRequest forgotPasswordRequest) {
         String email = forgotPasswordRequest.getEmail().trim().toLowerCase();
         try {
-            User user = userRepository.findByEmail(email).orElseThrow(
+            User user = userRepository.findByEmailAndDeletedFalse(email).orElseThrow(
                     ResourceNotFoundException::new
             );
             String otpToBeSend = otpService.getOtpForEmail(email);
@@ -231,7 +231,7 @@ public class AuthenticationServiceImplementation implements AuthenticationServic
         String email = registerVerifyRequest.getEmail().trim().toLowerCase();
         String otp = registerVerifyRequest.getOtp().trim();
         try {
-            User user = userRepository.findByEmail(email).orElseThrow(
+            User user = userRepository.findByEmailAndDeletedFalse(email).orElseThrow(
                     ResourceNotFoundException::new
             );
         } catch (ResourceNotFoundException ex) {
@@ -261,7 +261,7 @@ public class AuthenticationServiceImplementation implements AuthenticationServic
             return new ResponseEntity<>(GeneralAPIResponse.builder().message("Password and confirm password do not match").build(), HttpStatus.BAD_REQUEST);
         }
         try {
-            User user = userRepository.findByEmail(email).orElseThrow(
+            User user = userRepository.findByEmailAndDeletedFalse(email).orElseThrow(
                     ResourceNotFoundException::new
             );
             user.setPassword(passwordEncoder.encode(newPassword));
@@ -279,7 +279,7 @@ public class AuthenticationServiceImplementation implements AuthenticationServic
     public ResponseEntity<?> myProfile(ForgotPasswordRequest forgotPasswordRequest) {
         String email = forgotPasswordRequest.getEmail().trim().toLowerCase();
         try {
-            User user = userRepository.findByEmail(email).orElseThrow(
+            User user = userRepository.findByEmailAndDeletedFalse(email).orElseThrow(
                     ResourceNotFoundException::new
             );
             return new ResponseEntity<>(UserProfile.builder()

--- a/front/src/app/dashboard/users/manage-users.component.ts
+++ b/front/src/app/dashboard/users/manage-users.component.ts
@@ -21,7 +21,7 @@ import { User, Role } from '../../models/user.model';
       </thead>
       <tbody>
         <tr *ngFor="let u of users">
-          <td>{{ u.firstName }} {{ u.lastName }}</td>
+          <td>{{ u.name.fullName }}</td>
           <td>{{ u.phoneNumber }}</td>
           <td>{{ u.email }}</td>
           <td>
@@ -37,11 +37,11 @@ import { User, Role } from '../../models/user.model';
     <form (ngSubmit)="save()">
       <label>
         Nome:
-        <input name="firstName" [(ngModel)]="selected.firstName" />
+        <input name="firstName" [(ngModel)]="selected.name.firstName" />
       </label>
       <label>
         Sobrenome:
-        <input name="lastName" [(ngModel)]="selected.lastName" />
+        <input name="lastName" [(ngModel)]="selected.name.lastName" />
       </label>
       <label>
         Telefone:

--- a/front/src/app/models/user.model.ts
+++ b/front/src/app/models/user.model.ts
@@ -7,12 +7,18 @@ export enum Role {
   VENDEDOR = 'VENDEDOR'
 }
 
-export interface User {
-  id: number;
+export interface Name {
   firstName: string;
   lastName: string;
+  fullName: string;
+}
+
+export interface User {
+  id: number;
+  name: Name;
   email: string;
   phoneNumber: string;
   gender?: string;
   role: Role;
+  fullName: string;
 }


### PR DESCRIPTION
## Summary
- support soft delete for users
- hide user authorities in API
- update repository and services to filter deleted users
- adjust user management component to use `name.fullName`
- align User interface with backend response

## Testing
- `npm install`
- `npm run build`
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685878837a54832995b1c929307be7f9