### PR TITLE
Fix ResponseEntity type in delete endpoint

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/controller/UserController.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/controller/UserController.java
@@ -59,7 +59,7 @@ public class UserController {
                     // Explicitly set the generic type to avoid Optional inferring Object
                     return ResponseEntity.<Void>noContent().build();
                 })
-                .orElseGet(() -> ResponseEntity.notFound().build());
+                .orElseGet(() -> ResponseEntity.<Void>notFound().build());
     }
 
     public record RoleChangeRequest(Role role) {}


### PR DESCRIPTION
## Summary
- ensure `delete` endpoint returns `ResponseEntity<Void>`

## Testing
- `./mvnw -DskipTests package` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68588402762c8329800b9bd9aae63ad4