### PR TITLE
Fix generator name and response typo

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/User.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/User.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class User implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "user_seq")
-    @SequenceGenerator(name = "user_Seq", sequenceName = "user_sequence", allocationSize = 1)
+    @SequenceGenerator(name = "user_seq", sequenceName = "user_sequence", allocationSize = 1)
     private Long id;
 
     @Embedded

--- a/back/src/main/java/com/securitygateway/loginboilerplate/service/implementation/AuthenticationServiceImplementation.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/service/implementation/AuthenticationServiceImplementation.java
@@ -236,7 +236,7 @@ public class AuthenticationServiceImplementation implements AuthenticationServic
             );
         } catch (ResourceNotFoundException ex) {
             log.info("user with email {} not found in database ", email);
-            return new ResponseEntity<>(GeneralAPIResponse.builder().message("iUser with this email does not exist").build(), HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(GeneralAPIResponse.builder().message("User with this email does not exist").build(), HttpStatus.NOT_FOUND);
         }
         String cachedOtp = cacheManager.getCache("user").get(email, String.class);
         if (cachedOtp == null) {


### PR DESCRIPTION
## Summary
- correct sequence generator name in `User` entity
- fix typo in user verification message

## Testing
- `./mvnw -q -o test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68588641852c83299e8524b23d8253e3