### PR TITLE
Fix user registration with identity ID strategy

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/User.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/User.java
@@ -26,8 +26,7 @@ import java.util.List;
 @Table(name = "users")
 public class User implements UserDetails {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "user_seq")
-    @SequenceGenerator(name = "user_seq", sequenceName = "user_sequence", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Embedded


### PR DESCRIPTION
## Summary
- use `GenerationType.IDENTITY` for user IDs so Postgres handles auto-increment

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68588a60f4b48329b13784705d5ac071