### PR TITLE
Add CRM entities and controllers

### DIFF
--- a/back/src/main/java/com/securitygateway/crm/controller/AddressController.java
+++ b/back/src/main/java/com/securitygateway/crm/controller/AddressController.java
@@ -1,0 +1,55 @@
+package com.securitygateway.crm.controller;
+
+import com.securitygateway.crm.model.Address;
+import com.securitygateway.crm.repository.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/addresses")
+@RequiredArgsConstructor
+public class AddressController {
+
+    private final AddressRepository addressRepository;
+
+    @GetMapping
+    public List<Address> all() {
+        return addressRepository.findAll(Sort.by(Sort.Direction.ASC, "id"));
+    }
+
+    @PostMapping
+    public ResponseEntity<Address> create(@RequestBody Address address) {
+        return new ResponseEntity<>(addressRepository.save(address), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Address> get(@PathVariable Long id) {
+        return addressRepository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Address> update(@PathVariable Long id, @RequestBody Address updated) {
+        return addressRepository.findById(id)
+                .map(existing -> {
+                    updated.setId(existing.getId());
+                    return ResponseEntity.ok(addressRepository.save(updated));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (!addressRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        addressRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/back/src/main/java/com/securitygateway/crm/controller/ContractController.java
+++ b/back/src/main/java/com/securitygateway/crm/controller/ContractController.java
@@ -1,0 +1,55 @@
+package com.securitygateway.crm.controller;
+
+import com.securitygateway.crm.model.Contract;
+import com.securitygateway.crm.repository.ContractRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/contracts")
+@RequiredArgsConstructor
+public class ContractController {
+
+    private final ContractRepository contractRepository;
+
+    @GetMapping
+    public List<Contract> all() {
+        return contractRepository.findAll(Sort.by(Sort.Direction.ASC, "id"));
+    }
+
+    @PostMapping
+    public ResponseEntity<Contract> create(@RequestBody Contract contract) {
+        return new ResponseEntity<>(contractRepository.save(contract), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Contract> get(@PathVariable Long id) {
+        return contractRepository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Contract> update(@PathVariable Long id, @RequestBody Contract updated) {
+        return contractRepository.findById(id)
+                .map(existing -> {
+                    updated.setId(existing.getId());
+                    return ResponseEntity.ok(contractRepository.save(updated));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (!contractRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        contractRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/back/src/main/java/com/securitygateway/crm/controller/ProposalController.java
+++ b/back/src/main/java/com/securitygateway/crm/controller/ProposalController.java
@@ -1,0 +1,55 @@
+package com.securitygateway.crm.controller;
+
+import com.securitygateway.crm.model.Proposal;
+import com.securitygateway.crm.repository.ProposalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/proposals")
+@RequiredArgsConstructor
+public class ProposalController {
+
+    private final ProposalRepository proposalRepository;
+
+    @GetMapping
+    public List<Proposal> all() {
+        return proposalRepository.findAll(Sort.by(Sort.Direction.ASC, "id"));
+    }
+
+    @PostMapping
+    public ResponseEntity<Proposal> create(@RequestBody Proposal proposal) {
+        return new ResponseEntity<>(proposalRepository.save(proposal), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Proposal> get(@PathVariable Long id) {
+        return proposalRepository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Proposal> update(@PathVariable Long id, @RequestBody Proposal updated) {
+        return proposalRepository.findById(id)
+                .map(existing -> {
+                    updated.setId(existing.getId());
+                    return ResponseEntity.ok(proposalRepository.save(updated));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (!proposalRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        proposalRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/back/src/main/java/com/securitygateway/crm/model/Client.java
+++ b/back/src/main/java/com/securitygateway/crm/model/Client.java
@@ -42,4 +42,15 @@ public class Client {
     private User proprietario;
     private LocalDate validade;
     private LocalDateTime ultimaAtualizacao;
+
+    @PrePersist
+    private void onCreate() {
+        dataCriacao = LocalDateTime.now();
+        ultimaAtualizacao = dataCriacao;
+    }
+
+    @PreUpdate
+    private void onUpdate() {
+        ultimaAtualizacao = LocalDateTime.now();
+    }
 }

--- a/front/src/app/models/address.model.ts
+++ b/front/src/app/models/address.model.ts
@@ -1,0 +1,11 @@
+export interface Address {
+  id?: number;
+  logradouro: string;
+  numero: string;
+  complemento?: string;
+  bairro: string;
+  cidade: string;
+  estado: string;
+  cep: string;
+  pais: string;
+}

--- a/front/src/app/models/client.model.ts
+++ b/front/src/app/models/client.model.ts
@@ -1,0 +1,20 @@
+import { Address } from './address.model';
+import { Proposal } from './proposal.model';
+import { Contract } from './contract.model';
+
+export interface Client {
+  id?: string;
+  dataCriacao?: string;
+  enderecos: Address[];
+  cpf: string;
+  email: string;
+  cidade: string;
+  origem: string;
+  propostas: Proposal[];
+  contratos: Contract[];
+  notas?: string;
+  visualizacoes?: number;
+  proprietario: any;
+  validade: string;
+  ultimaAtualizacao?: string;
+}

--- a/front/src/app/models/contract.model.ts
+++ b/front/src/app/models/contract.model.ts
@@ -1,0 +1,10 @@
+export interface Contract {
+  id?: number;
+  cliente: any;
+  proposta: any;
+  dataAssinatura: string;
+  validadeProposta: string;
+  status: string;
+  formaPagamento: string;
+  valorTotal: number;
+}

--- a/front/src/app/models/proposal.model.ts
+++ b/front/src/app/models/proposal.model.ts
@@ -1,0 +1,18 @@
+export interface Proposal {
+  id?: number;
+  potenciaInstaladaRecomendada: string;
+  numeroModulos: number;
+  inversor: string;
+  estrutura: string;
+  cabeamento: string;
+  outros?: string;
+  valor: number;
+  parcelas: number;
+  valorParcelado: number;
+  formaPagamento: string;
+  metodoPagamento: string;
+  garantias: string;
+  validade: string;
+  horarioRegistro: string;
+  visualizacoes: number;
+}

--- a/front/src/app/services/client.service.ts
+++ b/front/src/app/services/client.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environmet/environment';
+import { Observable } from 'rxjs';
+import { Client } from '../models/client.model';
+
+@Injectable({ providedIn: 'root' })
+export class ClientService {
+  private apiUrl = `${environment.apiUrl}/clients`;
+  constructor(private http: HttpClient) {}
+
+  list(): Observable<Client[]> {
+    return this.http.get<Client[]>(this.apiUrl);
+  }
+
+  create(client: Client): Observable<Client> {
+    return this.http.post<Client>(this.apiUrl, client);
+  }
+
+  update(id: string, client: Client): Observable<Client> {
+    return this.http.put<Client>(`${this.apiUrl}/${id}`, client);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add controllers for address, proposal and contract
- add automatic timestamp handling in `Client` entity
- add front-end models for address, proposal, contract, and client
- add `ClientService` for API access

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588f3d20b483298ca7b8432af86b8e