### PR TITLE
Client management UI and email creation

### DIFF
--- a/front/src/app/dashboard/clients/manage-clients.component.html
+++ b/front/src/app/dashboard/clients/manage-clients.component.html
@@ -1,0 +1,46 @@
+<div>
+  <table class="clients-table">
+    <thead>
+      <tr>
+        <th>Email</th>
+        <th>CPF</th>
+        <th>Cidade</th>
+        <th>Ações</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let c of clients">
+        <td>{{ c.email }}</td>
+        <td>{{ c.cpf }}</td>
+        <td>{{ c.cidade }}</td>
+        <td>
+          <button (click)="edit(c)">Editar</button>
+          <button (click)="confirmRemove(c.id)">Remover</button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <button class="add-button" (click)="openAdd()">Adicionar cliente</button>
+
+  <div class="popup" *ngIf="popupOpen">
+    <form (ngSubmit)="save()" class="form">
+      <label>CPF:
+        <input name="cpf" [(ngModel)]="selected.cpf" required>
+      </label>
+      <label>Email:
+        <input name="email" [(ngModel)]="selected.email" required>
+      </label>
+      <label>Cidade:
+        <input name="cidade" [(ngModel)]="selected.cidade">
+      </label>
+      <label>Origem:
+        <input name="origem" [(ngModel)]="selected.origem">
+      </label>
+      <div class="actions">
+        <button type="submit">Salvar</button>
+        <button type="button" (click)="cancel()">Cancelar</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/front/src/app/dashboard/clients/manage-clients.component.scss
+++ b/front/src/app/dashboard/clients/manage-clients.component.scss
@@ -1,0 +1,29 @@
+.clients-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.clients-table th,
+.clients-table td {
+  padding: 8px;
+  border: 1px solid #ccc;
+}
+.add-button {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+}
+.popup {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  padding: 16px;
+  border: 1px solid #ccc;
+}
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}

--- a/front/src/app/dashboard/clients/manage-clients.component.ts
+++ b/front/src/app/dashboard/clients/manage-clients.component.ts
@@ -1,10 +1,82 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ClientService } from '../../services/client.service';
+import { Client } from '../../models/client.model';
 
 @Component({
   selector: 'app-manage-clients',
   standalone: true,
-  imports: [CommonModule],
-  template: '<p>Gerenciar Clientes</p>'
+  imports: [CommonModule, FormsModule],
+  templateUrl: './manage-clients.component.html',
+  styleUrls: ['./manage-clients.component.scss']
 })
-export class ManageClientsComponent {}
+export class ManageClientsComponent implements OnInit {
+  clients: Client[] = [];
+  selected!: Client;
+  popupOpen = false;
+  editing = false;
+
+  emptyClient(): Client {
+    return {
+      enderecos: [],
+      cpf: '',
+      email: '',
+      cidade: '',
+      origem: '',
+      propostas: [],
+      contratos: [],
+      proprietario: null,
+      validade: ''
+    };
+  }
+
+  constructor(private clientService: ClientService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load() {
+    this.clientService.list().subscribe(c => {
+      this.clients = c.sort((a, b) => a.email.localeCompare(b.email));
+    });
+  }
+
+  openAdd() {
+    this.selected = this.emptyClient();
+    this.editing = false;
+    this.popupOpen = true;
+  }
+
+  edit(client: Client) {
+    this.selected = { ...client };
+    this.editing = true;
+    this.popupOpen = true;
+  }
+
+  cancel() {
+    this.popupOpen = false;
+  }
+
+  save() {
+    if (this.editing && this.selected.id) {
+      this.clientService.update(this.selected.id, this.selected).subscribe(() => {
+        this.popupOpen = false;
+        this.load();
+      });
+    } else {
+      this.clientService.create(this.selected).subscribe(() => {
+        this.popupOpen = false;
+        this.load();
+      });
+    }
+  }
+
+  confirmRemove(id: string | undefined) {
+    if (!id) return;
+    if (confirm('Remover cliente?')) {
+      this.clientService.delete(id).subscribe(() => this.load());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- send welcome emails when creating clients
- create user accounts for new clients with default passwords
- add manage clients page with add/edit dialog

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685892d1144c8329935dfb7120c08ec0