### PR TITLE
Fix password field mismatch in User builder

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/User.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/User.java
@@ -40,7 +40,7 @@ public class User implements UserDetails {
 
     @NotBlank(message = "Password can't be blank")
     @Column(nullable = false)
-    private String Password;
+    private String password;
 
     @Enumerated(EnumType.STRING)
     @NotNull(message = "Choose your gender please")


### PR DESCRIPTION
## Summary
- correct case of `password` field in `User` entity

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to repo.maven.apache.org being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685894a80d988329a1eb079dcf3039bc